### PR TITLE
컴바인 스터디 4주차

### DIFF
--- a/Baemin/Baemin/Presentation/Login/LoginBottomSheetViewController.swift
+++ b/Baemin/Baemin/Presentation/Login/LoginBottomSheetViewController.swift
@@ -5,13 +5,12 @@
 //  Created by sun on 10/31/25.
 //
 
-
 import UIKit
 
 import SnapKit
 import Then
 
-final class LoginBottomSheetViewController: UIViewController {
+final class LoginBottomSheetViewController: BaseViewController {
 
     var onConfirm: ((String) -> Void)?
 
@@ -113,4 +112,3 @@ extension LoginBottomSheetViewController: UITextFieldDelegate {
         return true
     }
 }
-

--- a/Baemin/Baemin/Presentation/Login/LoginViewController.swift
+++ b/Baemin/Baemin/Presentation/Login/LoginViewController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+import Combine
 import SnapKit
 import Then
 
@@ -60,6 +61,11 @@ final class LoginViewController: BaseViewController {
         $0.spacing = 12
     }
     
+    // MARK: - Properties
+
+    private let viewModel = LoginViewModel()
+    private var cancellables = Set<AnyCancellable>()
+    
     // MARK: - Lifecycle
     
     override func setUI() {
@@ -102,25 +108,54 @@ final class LoginViewController: BaseViewController {
     }
     
     override func setAction() {
-        let refresh = { [weak self] in
-            guard let self else { return }
-            self.loginButton.setActive(
-                !self.emailField.text.isEmpty &&
-                !self.passwordField.text.isEmpty
-            )
+        bindViewModel()
+        bindUI()
+    }
+    
+    // MARK: - Bindings
+
+    private func bindViewModel() {
+        viewModel.$isLoginEnabled
+            .receive(on: RunLoop.main)
+            .sink { [weak self] isActive in
+                self?.loginButton.setActive(isActive)
+            }
+            .store(in: &cancellables)
+
+        viewModel.event
+            .receive(on: RunLoop.main)
+            .sink { [weak self] event in
+                guard let self else { return }
+                switch event {
+                case .showValidationError(let error):
+                    ToastMessage.show(in: view, message: error.message)
+                    focus(for: error.field)
+                case .navigateToWelcome(let email):
+                    navigateToWelcome(email: email)
+                }
+            }
+            .store(in: &cancellables)
+    }
+
+    private func bindUI() {
+        emailField.onTextChanged = { [weak self] text in
+            self?.viewModel.email = text
         }
-        
-        emailField.onTextChanged = { _ in refresh() }
-        passwordField.onTextChanged = { _ in refresh() }
-        refresh()
-        
-        emailField.onReturn = { [weak self] in self?.passwordField.focus() }
+
+        passwordField.onTextChanged = { [weak self] text in
+            self?.viewModel.password = text
+        }
+
+        emailField.onReturn = { [weak self] in
+            self?.passwordField.focus()
+        }
+
         passwordField.onReturn = { [weak self] in
             guard let self else { return }
-            self.view.endEditing(true)
-            if self.loginButton.isActive { self.performLogin() }
+            view.endEditing(true)
+            viewModel.login()
         }
-        
+
         loginButton.addTarget(self, action: #selector(loginButtonTapped), for: .touchUpInside)
         findAccountButton.addTarget(self, action: #selector(findAccountTapped), for: .touchUpInside)
     }
@@ -128,23 +163,12 @@ final class LoginViewController: BaseViewController {
     // MARK: - Actions
     
     @objc private func loginButtonTapped() {
-        performLogin()
+        viewModel.login()
     }
     
-    private func performLogin() {
-        let email = emailField.text
-        let password = passwordField.text
-        
-        guard !email.isEmpty, !password.isEmpty else { return }
-        
-        if let invalid = validateSubmission(email: email, password: password) {
-            ToastMessage.show(in: view, message: invalid.message)
-            focus(for: invalid.field)
-            return
-        }
-        
-        let vc = WelcomeViewController()
-        vc.email = email
+    private func navigateToWelcome(email: String) {
+        let welcomeViewModel = WelcomeViewModel(email: email)
+        let vc = WelcomeViewController(viewModel: welcomeViewModel)
         vc.delegate = self
         
         if let nav = navigationController {
@@ -155,7 +179,7 @@ final class LoginViewController: BaseViewController {
             present(nav, animated: true)
         }
     }
-    
+
     @objc private func findAccountTapped() {
         let sheet = LoginBottomSheetViewController()
         
@@ -183,37 +207,23 @@ final class LoginViewController: BaseViewController {
     }
 }
 
-// MARK: - Validation
+// MARK: - Focus & Delegate
 
 extension LoginViewController {
     
-    private enum InvalidField { case email, password }
-    
-    private func validateSubmission(email: String, password: String)
-        -> (message: String, field: InvalidField)?
-    {
-        if !Validator.isValidEmail(email) {
-            return ("이메일 형식이 달라요", .email)
-        }
-        if !Validator.isValidPassword(password) {
-            return ("비밀번호 형식이 달라요", .password)
-        }
-        return nil
-    }
-    
-    private func focus(for field: InvalidField) {
+    private func focus(for field: LoginViewModel.InvalidField) {
         switch field {
-        case .email: emailField.focus()
-        case .password: passwordField.focus()
+        case .email:
+            emailField.focus()
+        case .password:
+            passwordField.focus()
         }
     }
 }
-
-// MARK: - Welcome Delegate
 
 extension LoginViewController: WelcomeViewControllerDelegate {
     func didTapBackButton(email: String) {
+        viewModel.email = email
         emailField.setText(email)
     }
 }
-

--- a/Baemin/Baemin/Presentation/Login/LoginViewModel.swift
+++ b/Baemin/Baemin/Presentation/Login/LoginViewModel.swift
@@ -1,0 +1,85 @@
+//
+//  LoginViewModel.swift
+//  Baemin
+//
+//  Created by sun on 12/3/25.
+//
+
+import Foundation
+
+import Combine
+
+final class LoginViewModel {
+
+    enum InvalidField {
+        case email
+        case password
+    }
+
+    struct ValidationError {
+        let message: String
+        let field: InvalidField
+    }
+
+    enum Event {
+        case showValidationError(ValidationError)
+        case navigateToWelcome(email: String)
+    }
+
+    // MARK: - Input
+
+    @Published var email: String = ""
+    @Published var password: String = ""
+
+    // MARK: - Output
+
+    @Published private(set) var isLoginEnabled: Bool = false
+    let event = PassthroughSubject<Event, Never>()
+
+    // MARK: - Properties
+
+    private var cancellables = Set<AnyCancellable>()
+
+    // MARK: - Init
+
+    init() {
+        Publishers.CombineLatest($email, $password)
+            .map { !$0.0.isEmpty && !$0.1.isEmpty }
+            .removeDuplicates()
+            .assign(to: &$isLoginEnabled)
+    }
+
+    // MARK: - Public
+
+    func login() {
+        let email = email
+        let password = password
+
+        guard !email.isEmpty, !password.isEmpty else { return }
+
+        if let error = validateSubmission(email: email, password: password) {
+            event.send(.showValidationError(error))
+            return
+        }
+
+        event.send(.navigateToWelcome(email: email))
+    }
+
+    // MARK: - Private
+
+    private func validateSubmission(email: String, password: String) -> ValidationError? {
+        if !Validator.isValidEmail(email) {
+            return ValidationError(
+                message: "이메일 형식이 달라요",
+                field: .email
+            )
+        }
+        if !Validator.isValidPassword(password) {
+            return ValidationError(
+                message: "비밀번호 형식이 달라요",
+                field: .password
+            )
+        }
+        return nil
+    }
+}

--- a/Baemin/Baemin/Presentation/Login/WelcomeViewController.swift
+++ b/Baemin/Baemin/Presentation/Login/WelcomeViewController.swift
@@ -6,6 +6,8 @@
 //
 
 import UIKit
+
+import Combine
 import SnapKit
 import Then
 
@@ -20,7 +22,6 @@ protocol WelcomeViewControllerDelegate: AnyObject {
 final class WelcomeViewController: BaseViewController {
     
     weak var delegate: WelcomeViewControllerDelegate?
-    var email: String = ""
 
     // MARK: - UI
     
@@ -60,6 +61,23 @@ final class WelcomeViewController: BaseViewController {
         $0.alignment = .fill
         $0.distribution = .fill
         $0.spacing = 24
+    }
+
+    // MARK: - Properties
+
+    private let viewModel: WelcomeViewModel
+    private var cancellables = Set<AnyCancellable>()
+
+    // MARK: - Init
+
+    init(viewModel: WelcomeViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
 
     // MARK: - Lifecycle
@@ -116,9 +134,25 @@ final class WelcomeViewController: BaseViewController {
     }
 
     override func setAction() {
-        if !email.isEmpty {
-            subtitleLabel.text = "\(email)님 반가워요!"
-        }
+        bindViewModel()
+    }
+
+    // MARK: - Bindings
+
+    private func bindViewModel() {
+        viewModel.$titleText
+            .receive(on: RunLoop.main)
+            .sink { [weak self] text in
+                self?.titleLabel.text = text
+            }
+            .store(in: &cancellables)
+
+        viewModel.$subtitleText
+            .receive(on: RunLoop.main)
+            .sink { [weak self] text in
+                self?.subtitleLabel.text = text
+            }
+            .store(in: &cancellables)
     }
 
     // MARK: - Navigation
@@ -138,12 +172,12 @@ final class WelcomeViewController: BaseViewController {
     // MARK: - Actions
     
     @objc private func didTapBackButtonAction() {
-        delegate?.didTapBackButton(email: email)
+        delegate?.didTapBackButton(email: viewModel.email)
         goToBaeminTabBar()
     }
 
     private func notifyAndClose() {
-        delegate?.didTapBackButton(email: email)
+        delegate?.didTapBackButton(email: viewModel.email)
 
         if let nav = navigationController {
             if nav.viewControllers.first == self {

--- a/Baemin/Baemin/Presentation/Login/WelcomeViewModel.swift
+++ b/Baemin/Baemin/Presentation/Login/WelcomeViewModel.swift
@@ -1,0 +1,38 @@
+//
+//  WelcomeViewModel.swift
+//  Baemin
+//
+//  Created by sun on 12/3/25.
+//
+
+import Foundation
+
+import Combine
+
+final class WelcomeViewModel {
+
+    // MARK: - Input
+
+    @Published var email: String
+
+    // MARK: - Output
+
+    @Published private(set) var titleText: String = "환영합니다"
+    @Published private(set) var subtitleText: String = "반가워요!"
+
+    // MARK: - Properties
+
+    private var cancellables = Set<AnyCancellable>()
+
+    // MARK: - Init
+
+    init(email: String) {
+        self.email = email
+
+        $email
+            .map { email in
+                email.isEmpty ? "반가워요!" : "\(email)님 반가워요!"
+            }
+            .assign(to: &$subtitleText)
+    }
+}


### PR DESCRIPTION
## ☀️ 작업 내용
- 로그인 → 웰컴 로직 MVVM+Combine으로 리팩토링

|    구현 내용    |    iPhone 16 pro   |
| :-------------: | :----------: | 
| 로그인 → 웰컴 | <img src = "https://github.com/user-attachments/assets/4b76efe5-f9f1-46ce-9a3b-c54e49d90705" width ="250"> |

## 🌤️ Login Flow 설명해보자면
### 1️⃣ 유저가 텍스트필드에 타이핑한다
```Swift
emailField.onTextChanged = { [weak self] text in
    self?.viewModel.email = text
}

passwordField.onTextChanged = { [weak self] text in
    self?.viewModel.password = text
}
```
유저가 emailField, passwordField에 글자를 입력하면  LoginTextField 안에서 가지고 있던 `onTextChanged` 클로저가 호출

### 2️⃣ ViewModel 내부의 @Published 값들이 변화한다
```Swift
@Published var email: String = ""
@Published var password: String = ""
```
방금 View가 viewModel.email / viewModel.password를 바꿔줬기 때문에 `@Published` 프로퍼티들이 변경 이벤트를 방출
이 변경 이벤트를 Combine 스트림이 받아서 다음 연산으로 흘려보냄

### 3️⃣ CombineLatest가 로그인 버튼 활성화 여부를 계산
```Swift
Publishers.CombineLatest($email, $password)
    .map { !$0.0.isEmpty && !$0.1.isEmpty }
    .removeDuplicates()
    .assign(to: &$isLoginEnabled)
```
$email, $password는 @Published의 Publisher 버전
둘 중 하나라도 바뀌면 `CombineLatest`가 (email, password) 쌍을 넘겨줌

`map`에서
- 둘 다 비어 있지 않으면 true
- 하나라도 비어 있으면 false

그 결과가 `isLoginEnabled`에 들어감

### 4️⃣ View는 isLoginEnabled를 구독해서 버튼 상태를 바꾼다
```Swift
viewModel.$isLoginEnabled
    .receive(on: RunLoop.main)
    .sink { [weak self] isActive in
        self?.loginButton.setActive(isActive)
    }
    .store(in: &cancellables)
```
ViewController는 `viewModel.$isLoginEnabled`를 구독 중
값이 바뀔 때마다 sink 클로저가 호출되고 그 안에서 `loginButton.setActive(isActive)` 호출

### 5️⃣ 유저가 로그인 버튼을 탭한다
```Swift
@objc private func loginButtonTapped() {
    viewModel.login()
}
```
버튼 탭 → ViewController는 `viewModel.login()`만 호출

### 6️⃣ ViewModel.login()에서 검증 + 이벤트 방출
```Swift
func login() {
    let email = email
    let password = password

    guard !email.isEmpty, !password.isEmpty else { return }

    if let error = validateSubmission(email: email, password: password) {
        event.send(.showValidationError(error))
        return
    }

    event.send(.navigateToWelcome(email: email))
}
```
현재 ViewModel이 들고 있는 email, password를 읽어서, 비어 있으면 그냥 리턴 (버튼 활성화 체크 되어잇으니까,,, 웬만하면 이게 걸릴 일은 없겟조?)

`validateSubmission`으로 형식 검증
- 실패 시 → `.showValidationError` 이벤트
- 성공 시 → `.navigateToWelcome(email:)` 이벤트

### 7️⃣ ViewController가 event 스트림을 구독해서 UI/네비게이션 처리
```Swift
viewModel.event
    .receive(on: RunLoop.main)
    .sink { [weak self] event in
        guard let self else { return }
        switch event {
        case .showValidationError(let error):
            ToastMessage.show(in: view, message: error.message)
            focus(for: error.field)

        case .navigateToWelcome(let email):
            navigateToWelcome(email: email)
        }
    }
    .store(in: &cancellables)
```

- ViewController는 event를 구독 중
- ViewModel이 `event.send(...)`를 호출하면 여기로 도착
   - `.showValidationError` → 토스트 보여주고 해당 필드에 포커스
   - `.navigateToWelcome` → navigateToWelcome(email:)로 화면 전환


## 🌦️ 플로우 정리
### Login Flow
```
View(텍스트필드) → ViewModel(@Published) → Combine으로 버튼 상태 계산 
→ ViewModel.login() → Event → View가 Toast/네비게이션
```

### Welcome Flow
```
LoginView에서 email을 가진 WelcomeViewModel 생성 → View는 ViewModel의 subtitleText만 구독 
→ 버튼 탭 시 delegate로 email 되돌림 → LoginView의 ViewModel + UI 동기화
```

## 💬
> 제가 정리할 겸 주절주절 적었습니다,,, 잘못되었거나 수정할 점 있으면 코멘트 부탁드려여
